### PR TITLE
Use bcryptjs instead of bcrypt

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "babel-eslint": "^3.1.23",
     "babel-istanbul": "^0.2.10",
     "babel-loader": "^5.3.1",
-    "bcrypt": "^0.8.3",
+    "bcryptjs": "^2.3.0",
     "blocked": "^1.1.0",
     "bootstrap": "^3.3.5",
     "browser-sync": "^2.7.13",

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -1,5 +1,5 @@
 import mongoose from 'mongoose';
-// import bcrypt from 'bcrypt';
+// import bcrypt from 'bcryptjs';
 import jsonSelect from 'mongoose-json-select';
 
 // const SALT_WORK_FACTOR = 10;

--- a/server/rest.js
+++ b/server/rest.js
@@ -4,7 +4,7 @@ import Car from "./models/car";
 import Director from "./models/director";
 import Film from "./models/film";
 import User from "./models/user";
-import bcrypt from "bcrypt";
+import bcrypt from "bcryptjs";
 import uuid from "node-uuid";
 
 import koaRouter from "koa-router";


### PR DESCRIPTION
As the API are similar, bcryptjs ("bcrypt in plain javascript") seems a very suitable alternative to bcrypt. I spent two nights trying to install bcrypt on windows and eventually concluded that you couldn't do that without a nobel prize and a fair amount of luck. 
